### PR TITLE
feat: add .symai folder to volume for docker instance to ease configuration

### DIFF
--- a/.symai/symsh.config.json
+++ b/.symai/symsh.config.json
@@ -1,0 +1,16 @@
+{
+    "colors": {
+        "completion-menu.completion.current": "bg:#323232 #212121",
+        "completion-menu.completion": "bg:#800080 #212121",
+        "scrollbar.background": "bg:#222222",
+        "scrollbar.button": "bg:#776677",
+        "history-completion": "bg:#212121 #f5f5f5",
+        "path-completion": "bg:#800080 #f5f5f5",
+        "file-completion": "bg:#9040b2 #f5f5f5",
+        "history-completion-selected": "bg:#efefef #b3d7ff",
+        "path-completion-selected": "bg:#efefef #b3d7ff",
+        "file-completion-selected": "bg:#efefef #b3d7ff"
+    },
+    "map-nt-cmd": true,
+    "show-splash-screen": true
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,5 @@ services:
     command: uvicorn symai.endpoints.api:app --reload --host 0.0.0.0 --port 8999
     ports:
       - 8999:8999
+    volumes:
+      - .symai:/root/.symai


### PR DESCRIPTION
Create a `.symai` folder in the repository and link it as a volume in docker-compose to ease configuration when running docker.