### PR TITLE
Add support for gpt-4o-mini

### DIFF
--- a/symai/backend/engines/neurosymbolic/engine_openai_gptX_chat.py
+++ b/symai/backend/engines/neurosymbolic/engine_openai_gptX_chat.py
@@ -160,7 +160,8 @@ class GPTXChatEngine(Engine, OpenAIMixin):
             "gpt-4-0613",
             "gpt-4-32k-0613",
             "gpt-4-turbo",
-            "gpt-4o"
+            "gpt-4o",
+            "gpt-4o-mini"
             }:
             tokens_per_message = 3
             tokens_per_name = 1
@@ -326,7 +327,8 @@ class GPTXChatEngine(Engine, OpenAIMixin):
         if (self.model == 'gpt-4-vision-preview' or \
             self.model == 'gpt-4-turbo-2024-04-09' or \
             self.model == 'gpt-4-turbo' or \
-            self.model == 'gpt-4o') \
+            self.model == 'gpt-4o' or \
+            self.model == 'gpt-4o-mini') \
             and '<<vision:' in str(argument.prop.processed_input):
 
             parts = extract_pattern(str(argument.prop.processed_input))
@@ -393,7 +395,8 @@ class GPTXChatEngine(Engine, OpenAIMixin):
             ]}
         elif self.model == 'gpt-4-turbo-2024-04-09' or \
              self.model == 'gpt-4-turbo' or \
-             self.model == 'gpt-4o':
+             self.model == 'gpt-4o' or \
+             self.model == 'gpt-4o-mini':
 
             images = [{ 'type': 'image_url', "image_url": { "url": file }} for file in image_files]
             user_prompt = { "role": "user", "content": [

--- a/symai/backend/mixin/openai.py
+++ b/symai/backend/mixin/openai.py
@@ -10,6 +10,7 @@ SUPPORTED_MODELS = [
     'gpt-4-turbo',
     'gpt-4-turbo-2024-04-09',
     'gpt-4o',
+    'gpt-4o-mini',
     'text-embedding-ada-002',
     'text-embedding-3-small',
     'text-embedding-3-large'
@@ -36,7 +37,8 @@ class OpenAIMixin:
              self.model == 'gpt-4-turbo-2024-04-09' or \
              self.model == 'gpt-4-turbo' or \
              self.model == 'gpt-4-1106' or \
-             self.model == 'gpt-4o':
+             self.model == 'gpt-4o' or \
+             self.model == 'gpt-4o-mini':
             return 128_000
 
         elif self.model == 'gpt-4-32k' or \
@@ -80,7 +82,8 @@ class OpenAIMixin:
             return 8_192
 
         elif self.model == 'gpt-3.5-turbo-16k-0613' or \
-             self.model == 'gpt-3.5-turbo-16k':
+             self.model == 'gpt-3.5-turbo-16k' or \
+             self.model == 'gpt-4o-mini':
             return 16_384
 
     def api_embedding_dims(self):


### PR DESCRIPTION
Added support for the new `gpt-4o-mini` model.

- max tokens found under https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/