### PR TITLE
Bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,4 @@ wandb/
 tmp/
 dist/
 bin/
+.idea

--- a/symai/functional.py
+++ b/symai/functional.py
@@ -103,10 +103,9 @@ def _apply_preprocessors(argument, instance: Any, pre_processors: Optional[List[
         for pp in pre_processors:
             t = pp(argument)
             processed_input += t if t is not None else ''
-    elif argument.args and len(argument.args) > 0 and argument.prop.raw_input:
-       processed_input += ' '.join([str(a) for a in argument.args])
     else:
-       processed_input = instance
+        if argument.args and len(argument.args) > 0:
+            processed_input      += ' '.join([str(a) for a in argument.args])
     return processed_input
 
 

--- a/symai/functional.py
+++ b/symai/functional.py
@@ -175,14 +175,13 @@ def _process_query_single(engine,
 
     preprocessed_input = _apply_preprocessors(argument, instance, pre_processors)
     argument.prop.processed_input = preprocessed_input
-    executor_callback = argument.kwargs.get('executor_callback', None)
     engine.prepare(argument)
 
     result = None
     metadata = None
     for _ in range(trials):
         try:
-            outputs = executor_callback(argument)
+            outputs = engine.executor_callback(argument)
             result, metadata = _apply_postprocessors(outputs, argument.prop.return_constraint, post_processors, argument)
             break
         except Exception as e:


### PR DESCRIPTION
1. there was a bug in apply_preprocessors, when there are no preprocessors, the argument was not being properly sent to the engine in the batched scenario
2. in the previous version of scheduler i was passing the executor_callback in kwargs of Expressions, which is suboptimal. Now I bind it to the engine and it can be directly called from the engine. 